### PR TITLE
add Ownable dependency to CrucibleFactory

### DIFF
--- a/contracts/crucible/CrucibleFactory.sol
+++ b/contracts/crucible/CrucibleFactory.sol
@@ -3,6 +3,7 @@ pragma solidity 0.7.6;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 import {IFactory} from "../factory/IFactory.sol";
 import {IInstanceRegistry} from "../factory/InstanceRegistry.sol";
@@ -13,10 +14,12 @@ import {IUniversalVault} from "./Crucible.sol";
 /// @title CrucibleFactory
 contract CrucibleFactory is Ownable, IFactory, IInstanceRegistry, ERC721 {
     address private immutable _template;
+    using Strings for uint256;
 
     constructor(address template) ERC721("Alchemist Crucible v1", "CRUCIBLE-V1") Ownable() {
         require(template != address(0), "CrucibleFactory: invalid template");
         _template = template;
+        _setBaseURI('https://crucible.alchemist.wtf/nft/');
     }
 
     /* registry functions */
@@ -82,5 +85,27 @@ contract CrucibleFactory is Ownable, IFactory, IInstanceRegistry, ERC721 {
 
     function getTemplate() external view returns (address template) {
         return _template;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-tokenURI}.
+     */
+    function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
+        require(_exists(tokenId), "ERC721Metadata: URI query for nonexistent token");
+
+        string memory base = baseURI();
+
+        uint256 id;
+        assembly {
+            id := chainid()
+        }
+
+        // concatenate the tokenID and chain id to the baseURI
+        return string(abi.encodePacked(
+            base,
+            tokenId.toString(),
+            '?network=',
+            chainId.toString()
+        ));
     }
 }

--- a/contracts/crucible/CrucibleFactory.sol
+++ b/contracts/crucible/CrucibleFactory.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.7.6;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 import {IFactory} from "../factory/IFactory.sol";
 import {IInstanceRegistry} from "../factory/InstanceRegistry.sol";
@@ -10,10 +11,10 @@ import {ProxyFactory} from "../factory/ProxyFactory.sol";
 import {IUniversalVault} from "./Crucible.sol";
 
 /// @title CrucibleFactory
-contract CrucibleFactory is IFactory, IInstanceRegistry, ERC721 {
+contract CrucibleFactory is Ownable, IFactory, IInstanceRegistry, ERC721 {
     address private immutable _template;
 
-    constructor(address template) ERC721("Alchemist Crucible v1", "CRUCIBLE-V1") {
+    constructor(address template) ERC721("Alchemist Crucible v1", "CRUCIBLE-V1") Ownable() {
         require(template != address(0), "CrucibleFactory: invalid template");
         _template = template;
     }


### PR DESCRIPTION
I added the Ownable dependency to the CrucibleFactory to allow us to verify the contract on OpenSea.

Also added a custom tokenURI function.